### PR TITLE
[Hotfix] Add a reinterpretAsKeyedStream variation that does not overr…

### DIFF
--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/DataStreamUtils.java
@@ -209,6 +209,53 @@ public final class DataStreamUtils {
         return new KeyedStream<>(stream, partitionTransformation, keySelector, typeInfo);
     }
 
+    /**
+     * Reinterprets the given {@link DataStream} as a {@link KeyedStream}, which extracts keys with
+     * the given {@link KeySelector}. This method allows user to specify whether the given
+     * {@link DataStream} needs to be sorted by the Flink runtime in batch execution mode.
+     *
+     * <p>If sorting is needed for batch execution, Flink will sort the given {@link DataStream}
+     * by leveraging the shuffle service. In this case, the chaining strategy will be overridden to
+     * {@link org.apache.flink.streaming.api.operators.ChainingStrategy#HEAD HEAD} for
+     * the operator applied to this KeyedStream.
+     *
+     * <p>If the given {@link DataStream} is either already sorted for batch execution, or user
+     * knows the input {@link DataStream} does not need to be sorted. The user defined chaining
+     * strategy for the operator applied to this KeyedStream will still be honored.
+     *
+     * <p>IMPORTANT: For every partition of the base stream, the keys of events in the base stream
+     * must be partitioned exactly in the same way as if it was created through a {@link
+     * DataStream#keyBy(KeySelector)}.
+     *
+     * @param stream The data stream to reinterpret. For every partition, this stream must be
+     *     partitioned exactly in the same way as if it was created through a {@link
+     *     DataStream#keyBy(KeySelector)}.
+     * @param keySelector Function that defines how keys are extracted from the data stream.
+     * @param typeInfo Explicit type information about the key type.
+     * @param sortInputForBatchExecution sort the provided {@link DataStream} when executing
+     *        in batch mode.
+     * @param <T> Type of events in the data stream.
+     * @param <K> Type of the extracted keys.
+     * @return The reinterpretation of the {@link DataStream} as a {@link KeyedStream}.
+     */
+    public static <T, K> KeyedStream<T, K> reinterpretAsKeyedStream(
+            DataStream<T> stream,
+            KeySelector<T, K> keySelector,
+            TypeInformation<K> typeInfo,
+            boolean sortInputForBatchExecution) {
+
+        PartitionTransformation<T> partitionTransformation =
+                new PartitionTransformation<>(
+                        stream.getTransformation(), new ForwardPartitioner<>());
+
+        return new KeyedStream<>(
+                stream,
+                partitionTransformation,
+                keySelector,
+                typeInfo,
+                sortInputForBatchExecution);
+    }
+
     // ------------------------------------------------------------------------
 
     /** Private constructor to prevent instantiation. */

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/datastream/KeyedStream.java
@@ -102,6 +102,8 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
     /** The type of the key by which the stream is partitioned. */
     private final TypeInformation<KEY> keyType;
 
+    private final boolean sortInputForBatchExecution;
+
     /**
      * Creates a new {@link KeyedStream} using the given {@link KeySelector} to partition operator
      * state by key.
@@ -156,9 +158,34 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
             KeySelector<T, KEY> keySelector,
             TypeInformation<KEY> keyType) {
 
+        this(stream, partitionTransformation, keySelector, keyType, true);
+    }
+
+    /**
+     * Creates a new {@link KeyedStream} using the given {@link KeySelector} and {@link
+     * TypeInformation} to partition operator state by key, where the partitioning is defined by a
+     * {@link PartitionTransformation}.
+     *
+     * @param stream Base stream of data
+     * @param partitionTransformation Function that determines how the keys are distributed to
+     *     downstream operator(s)
+     * @param keySelector Function to extract keys from the base stream
+     * @param keyType Defines the type of the extracted keys
+     * @param sortInputForBatchExecution defines whether the input to this {@link KeyedStream}
+     *        needs to be sorted by the Flink runtime for when run in batch mode.
+     */
+    @Internal
+    KeyedStream(
+            DataStream<T> stream,
+            PartitionTransformation<T> partitionTransformation,
+            KeySelector<T, KEY> keySelector,
+            TypeInformation<KEY> keyType,
+            boolean sortInputForBatchExecution) {
+
         super(stream.getExecutionEnvironment(), partitionTransformation);
         this.keySelector = clean(keySelector);
         this.keyType = validateKeyType(keyType);
+        this.sortInputForBatchExecution = sortInputForBatchExecution;
     }
 
     /**
@@ -292,6 +319,7 @@ public class KeyedStream<T, KEY> extends DataStream<T> {
                 (OneInputTransformation<T, R>) returnStream.getTransformation();
         transform.setStateKeySelector(keySelector);
         transform.setStateKeyType(keyType);
+        transform.setSortInputForBatchExecution(sortInputForBatchExecution);
 
         return returnStream;
     }

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/api/transformations/OneInputTransformation.java
@@ -52,6 +52,8 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
 
     private TypeInformation<?> stateKeyType;
 
+    private boolean sortInputForBatchExecution;
+
     /**
      * Creates a new {@code OneInputTransformation} from the given input and operator.
      *
@@ -125,6 +127,14 @@ public class OneInputTransformation<IN, OUT> extends PhysicalTransformation<OUT>
 
     public TypeInformation<?> getStateKeyType() {
         return stateKeyType;
+    }
+
+    public void setSortInputForBatchExecution(boolean sortInputForBatchExecution) {
+        this.sortInputForBatchExecution = sortInputForBatchExecution;
+    }
+
+    public boolean getSortInputForBatchExecution() {
+        return sortInputForBatchExecution;
     }
 
     @Override

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/BatchExecutionUtils.java
@@ -46,11 +46,21 @@ public class BatchExecutionUtils {
             int transformationId,
             TransformationTranslator.Context context,
             StreamConfig.InputRequirement... inputRequirements) {
+        applyBatchExecutionSettings(transformationId, true, context, inputRequirements);
+    }
+
+    static void applyBatchExecutionSettings(
+            int transformationId,
+            boolean sortInput,
+            TransformationTranslator.Context context,
+            StreamConfig.InputRequirement... inputRequirements) {
         StreamNode node = context.getStreamGraph().getStreamNode(transformationId);
         boolean sortInputs = context.getGraphGeneratorConfig().get(ExecutionOptions.SORT_INPUTS);
         boolean isInputSelectable = isInputSelectable(node);
 
-        adjustChainingStrategy(node);
+        if (sortInput) {
+            adjustChainingStrategy(node);
+        }
 
         checkState(
                 !isInputSelectable || !sortInputs,

--- a/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
+++ b/flink-streaming-java/src/main/java/org/apache/flink/streaming/runtime/translators/OneInputTransformationTranslator.java
@@ -52,8 +52,12 @@ public final class OneInputTransformationTranslator<IN, OUT>
                         context);
         boolean isKeyed = keySelector != null;
         if (isKeyed) {
+            boolean sortInputRequired = transformation.getSortInputForBatchExecution();
             BatchExecutionUtils.applyBatchExecutionSettings(
-                    transformation.getId(), context, StreamConfig.InputRequirement.SORTED);
+                    transformation.getId(),
+                    sortInputRequired,
+                    context,
+                    StreamConfig.InputRequirement.SORTED);
         }
 
         return ids;


### PR DESCRIPTION
…ides the user specified chaining strategy.

<!--
*Thank you very much for contributing to Apache Flink - we are happy that you want to help us improve Flink. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

*Please understand that we do not do this to make contributions to Flink a hassle. In order to uphold a high standard of quality for code contributions, while at the same time managing a large number of contributions, we need contributors to prepare the contributions well, and give reviewers enough contextual information for the review. Please also understand that contributions that do not follow this guide will take longer to review and thus typically be picked up with lower priority by the community.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix] [docs] Fix typo in event time introduction` or `[hotfix] [javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can set up Azure Pipelines CI to do that following [this guide](https://cwiki.apache.org/confluence/display/FLINK/Azure+Pipelines#AzurePipelines-Tutorial:SettingupAzurePipelinesforaforkoftheFlinkrepository).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request makes task deployment go through the blob server, rather than through RPC. That way we avoid re-transferring them on each deployment (during recovery).)*


## Brief change log

*(for example:)*
  - *The TaskInfo is stored in the blob store on job creation time as a persistent artifact*
  - *Deployments RPC transmits only the blob storage reference*
  - *TaskManagers retrieve the TaskInfo from the blob cache*


## Verifying this change

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Added test that validates that TaskInfo is transferred only once across recoveries*
  - *Manually verified the change by running a 4 node cluser with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (yes / no)
  - The serializers: (yes / no / don't know)
  - The runtime per-record code paths (performance sensitive): (yes / no / don't know)
  - Anything that affects deployment or recovery: JobManager (and its components), Checkpointing, Kubernetes/Yarn/Mesos, ZooKeeper: (yes / no / don't know)
  - The S3 file system connector: (yes / no / don't know)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
